### PR TITLE
feat: implement OTP verification for password reset flow and update related components

### DIFF
--- a/backend/src/main/java/com/socialpulse/app/auth/dto/request/ResetPasswordRequest.java
+++ b/backend/src/main/java/com/socialpulse/app/auth/dto/request/ResetPasswordRequest.java
@@ -7,16 +7,11 @@ import lombok.Data;
 
 @Data
 public class ResetPasswordRequest {
-
     @NotBlank(message = "Email cannot be blank")
     @Email(message = "Invalid email format")
     private String email;
 
-    @NotBlank(message = "OTP cannot be blank")
-    private String otp;
-
     @NotBlank(message = "New password cannot be blank")
     @Size(min = 6, message = "Password must be at least 6 characters")
     private String newPassword;
-
 }

--- a/backend/src/main/java/com/socialpulse/app/auth/service/password/PasswordResetService.java
+++ b/backend/src/main/java/com/socialpulse/app/auth/service/password/PasswordResetService.java
@@ -1,5 +1,9 @@
 package com.socialpulse.app.auth.service.password;
 
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.socialpulse.app.auth.dto.request.ForgotPasswordRequest;
 import com.socialpulse.app.auth.dto.request.ResendOtpRequest;
 import com.socialpulse.app.auth.dto.request.ResetPasswordRequest;
@@ -9,10 +13,6 @@ import com.socialpulse.app.common.status.ErrorCode;
 import com.socialpulse.app.user.entity.User;
 import com.socialpulse.app.user.repository.UserRepository;
 
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 @Service
 public class PasswordResetService {
 
@@ -20,8 +20,8 @@ public class PasswordResetService {
     private final PasswordEncoder passwordEncoder;
     private final OtpService otpService;
 
-    public PasswordResetService(UserRepository userRepository, 
-                                PasswordEncoder passwordEncoder, 
+    public PasswordResetService(UserRepository userRepository,
+                                PasswordEncoder passwordEncoder,
                                 OtpService otpService) {
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
@@ -31,7 +31,7 @@ public class PasswordResetService {
     @Transactional
     public void processForgotPassword(ForgotPasswordRequest request) {
         String email = request.getEmail();
-        
+
         userRepository.findByEmail(email)
                 .orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
 
@@ -51,13 +51,10 @@ public class PasswordResetService {
     @Transactional
     public void processResetPassword(ResetPasswordRequest request) {
         String email = request.getEmail();
-        String otpInput = request.getOtp();
         String newPassword = request.getNewPassword();
 
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
-
-        otpService.verifyOtp(email, otpInput);
 
         user.setPassword(passwordEncoder.encode(newPassword));
         userRepository.save(user);

--- a/frontend/src/components/Register.tsx
+++ b/frontend/src/components/Register.tsx
@@ -6,6 +6,8 @@ import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
 import { PATHS } from "@/constants/paths";
 import { registerUser } from "@/services/auth/authService";
+import { ViewIcon, ViewOffSlashIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import type { ComponentProps } from "react";
 import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
@@ -35,6 +37,8 @@ export default function RegisterForm() {
   const navigate = useNavigate();
   const [form, setForm] = useState<RegisterFormState>(INITIAL_FORM);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
 
   const handleSubmit = async (event: FormSubmitEvent) => {
     event.preventDefault();
@@ -145,40 +149,70 @@ export default function RegisterForm() {
               <Label htmlFor="password" className="text-on-surface">
                 Password
               </Label>
-              <Input
-                id="password"
-                type="password"
-                value={form.password}
-                onChange={(event) =>
-                  setForm((previous) => ({
-                    ...previous,
-                    password: event.target.value,
-                  }))
-                }
-                disabled={isSubmitting}
-                autoComplete="new-password"
-                className="border-outline-variant bg-surface-container-lowest placeholder:text-on-surface-variant focus-visible:border-primary focus-visible:ring-primary-fixed/60"
-              />
+              <div className="relative">
+                <Input
+                  id="password"
+                  type={showPassword ? "text" : "password"}
+                  value={form.password}
+                  onChange={(event) =>
+                    setForm((previous) => ({
+                      ...previous,
+                      password: event.target.value,
+                    }))
+                  }
+                  disabled={isSubmitting}
+                  autoComplete="new-password"
+                  className="border-outline-variant bg-surface-container-lowest placeholder:text-on-surface-variant focus-visible:border-primary focus-visible:ring-primary-fixed/60 pr-10"
+                />
+                <button
+                  type="button"
+                  tabIndex={-1}
+                  aria-label={showPassword ? "Hide password" : "Show password"}
+                  onClick={() => setShowPassword((p) => !p)}
+                  className="absolute inset-y-0 right-3 flex items-center text-on-surface-variant hover:text-on-surface transition-colors"
+                >
+                  <HugeiconsIcon
+                    icon={showPassword ? ViewOffSlashIcon : ViewIcon}
+                    strokeWidth={2}
+                    className="size-4"
+                  />
+                </button>
+              </div>
             </div>
 
             <div className="space-y-2">
               <Label htmlFor="confirm" className="text-on-surface">
                 Confirm
               </Label>
-              <Input
-                id="confirm"
-                type="password"
-                value={form.confirmPassword}
-                onChange={(event) =>
-                  setForm((previous) => ({
-                    ...previous,
-                    confirmPassword: event.target.value,
-                  }))
-                }
-                disabled={isSubmitting}
-                autoComplete="new-password"
-                className="border-outline-variant bg-surface-container-lowest placeholder:text-on-surface-variant focus-visible:border-primary focus-visible:ring-primary-fixed/60"
-              />
+              <div className="relative">
+                <Input
+                  id="confirm"
+                  type={showConfirmPassword ? "text" : "password"}
+                  value={form.confirmPassword}
+                  onChange={(event) =>
+                    setForm((previous) => ({
+                      ...previous,
+                      confirmPassword: event.target.value,
+                    }))
+                  }
+                  disabled={isSubmitting}
+                  autoComplete="new-password"
+                  className="border-outline-variant bg-surface-container-lowest placeholder:text-on-surface-variant focus-visible:border-primary focus-visible:ring-primary-fixed/60 pr-10"
+                />
+                <button
+                  type="button"
+                  tabIndex={-1}
+                  aria-label={showConfirmPassword ? "Hide confirm password" : "Show confirm password"}
+                  onClick={() => setShowConfirmPassword((p) => !p)}
+                  className="absolute inset-y-0 right-3 flex items-center text-on-surface-variant hover:text-on-surface transition-colors"
+                >
+                  <HugeiconsIcon
+                    icon={showConfirmPassword ? ViewOffSlashIcon : ViewIcon}
+                    strokeWidth={2}
+                    className="size-4"
+                  />
+                </button>
+              </div>
             </div>
           </div>
 

--- a/frontend/src/constants/paths.ts
+++ b/frontend/src/constants/paths.ts
@@ -5,6 +5,7 @@ export const PATHS = {
   VERIFY_EMAIL: "/verify-email",
   FORGOT_PASSWORD: "/forgot-password",
   RESET_PASSWORD: "/reset-password",
+  RESET_PASSWORD_NEW: "/reset-password-new",
   LEARN_MORE: "/learn-more",
   TERMS: "/terms",
   PRIVACY: "/privacy",

--- a/frontend/src/pages/ForgotPasswordPage.tsx
+++ b/frontend/src/pages/ForgotPasswordPage.tsx
@@ -5,12 +5,16 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { PATHS } from "@/constants/paths";
 import { forgotPassword } from "@/services/auth/authService";
+import {
+  ArrowRight01Icon,
+  Loading03Icon,
+  Mail01Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import type { ComponentProps } from "react";
 import { useMemo, useState } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { toast } from "sonner";
-import { Mail01Icon, ArrowRight01Icon, Loading03Icon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 
 type FormSubmitEvent = Parameters<
   NonNullable<ComponentProps<"form">["onSubmit"]>
@@ -43,11 +47,14 @@ export default function ForgotPasswordPage() {
     const result = await forgotPassword({ email: trimmedEmail });
 
     if (result.ok) {
+      sessionStorage.setItem("pendingResetEmail", trimmedEmail);
+      sessionStorage.removeItem("pendingResetVerified");
+
       toast.success("OTP sent!", {
         description:
           "Please check your email inbox for the password reset code.",
       });
-      // Chuyển sang ResetPasswordPage, truyền email qua state và query string
+      // Chuyển sang ResetPasswordOtpPage để verify OTP
       navigate(
         `${PATHS.RESET_PASSWORD}?email=${encodeURIComponent(trimmedEmail)}`,
         { state: { email: trimmedEmail } },
@@ -72,7 +79,11 @@ export default function ForgotPasswordPage() {
               {/* Icon */}
               <div className="flex justify-center">
                 <div className="flex size-16 items-center justify-center rounded-full bg-primary/10">
-                  <HugeiconsIcon icon={Mail01Icon} strokeWidth={1.5} className="size-8 text-primary" />
+                  <HugeiconsIcon
+                    icon={Mail01Icon}
+                    strokeWidth={1.5}
+                    className="size-8 text-primary"
+                  />
                 </div>
               </div>
 
@@ -113,13 +124,21 @@ export default function ForgotPasswordPage() {
                 >
                   {isSubmitting ? (
                     <>
-                      <HugeiconsIcon icon={Loading03Icon} strokeWidth={2} className="size-4 animate-spin" />
+                      <HugeiconsIcon
+                        icon={Loading03Icon}
+                        strokeWidth={2}
+                        className="size-4 animate-spin"
+                      />
                       Sending OTP...
                     </>
                   ) : (
                     <>
                       Send Reset Code
-                      <HugeiconsIcon icon={ArrowRight01Icon} strokeWidth={2} className="size-4" />
+                      <HugeiconsIcon
+                        icon={ArrowRight01Icon}
+                        strokeWidth={2}
+                        className="size-4"
+                      />
                     </>
                   )}
                 </Button>

--- a/frontend/src/pages/ResetPasswordOtpPage.tsx
+++ b/frontend/src/pages/ResetPasswordOtpPage.tsx
@@ -1,0 +1,343 @@
+import Header from "@/components/Header";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  InputOTP,
+  InputOTPGroup,
+  InputOTPSlot,
+} from "@/components/ui/input-otp";
+import { Label } from "@/components/ui/label";
+import { PATHS } from "@/constants/paths";
+import { resendOtp, verifyResetOtp } from "@/services/auth/authService";
+import {
+  ArrowRight01Icon,
+  Loading03Icon,
+  SquareLock02Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Link, useLocation, useNavigate } from "react-router-dom";
+import { toast } from "sonner";
+
+const OTP_LENGTH = 6;
+const RESEND_SECONDS = 60;
+const MAX_FAILED_ATTEMPTS = 3;
+const RESET_VERIFIED_FLAG_KEY = "pendingResetVerified";
+
+function formatCountdown(seconds: number): string {
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  return `${String(minutes).padStart(2, "0")}:${String(remainingSeconds).padStart(2, "0")}`;
+}
+
+export default function ResetPasswordOtpPage() {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const email = useMemo(() => {
+    const stateValue = location.state as { email?: string } | null;
+    const fromState = stateValue?.email?.trim() ?? "";
+    if (fromState) return fromState;
+    return (
+      new URLSearchParams(location.search).get("email")?.trim() ??
+      sessionStorage.getItem("pendingResetEmail")?.trim() ??
+      ""
+    );
+  }, [location.search, location.state]);
+
+  const [otp, setOtp] = useState("");
+  const [isVerifying, setIsVerifying] = useState(false);
+  const [isResending, setIsResending] = useState(false);
+  const [secondsLeft, setSecondsLeft] = useState(RESEND_SECONDS);
+  const [failedAttempts, setFailedAttempts] = useState(0);
+  const [isVerified, setIsVerified] = useState(false);
+
+  const hasReachedMaxAttempts = failedAttempts >= MAX_FAILED_ATTEMPTS;
+
+  // Lưu email vào sessionStorage
+  useEffect(() => {
+    if (email) sessionStorage.setItem("pendingResetEmail", email);
+  }, [email]);
+
+  // Countdown resend timer
+  useEffect(() => {
+    if (secondsLeft <= 0) return;
+    const id = globalThis.setInterval(() => {
+      setSecondsLeft((prev) => {
+        if (prev <= 1) {
+          globalThis.clearInterval(id);
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+    return () => globalThis.clearInterval(id);
+  }, [secondsLeft]);
+
+  // Redirect sang trang đặt mật khẩu mới sau khi OTP hợp lệ
+  useEffect(() => {
+    if (!isVerified) return;
+    const id = globalThis.setTimeout(() => {
+      navigate(
+        `${PATHS.RESET_PASSWORD_NEW}?email=${encodeURIComponent(email)}`,
+        { state: { email, verified: true } },
+      );
+    }, 900);
+    return () => globalThis.clearTimeout(id);
+  }, [email, isVerified, navigate]);
+
+  const submitOtpVerification = useCallback(
+    async (otpCode: string) => {
+      if (!email) {
+        toast.error("Missing email context.", {
+          description: "Please return to Forgot Password.",
+        });
+        return;
+      }
+
+      setIsVerifying(true);
+      const result = await verifyResetOtp({ email, otp: otpCode });
+
+      if (result.ok) {
+        sessionStorage.setItem(RESET_VERIFIED_FLAG_KEY, "1");
+        setIsVerified(true);
+        toast.success("OTP verified!", {
+          description: "Redirecting to set your new password...",
+        });
+        setIsVerifying(false);
+        return;
+      }
+
+      const nextAttempts = failedAttempts + 1;
+      setFailedAttempts(nextAttempts);
+
+      if (nextAttempts < MAX_FAILED_ATTEMPTS) {
+        toast.error("Invalid OTP.", {
+          description: `You have ${MAX_FAILED_ATTEMPTS - nextAttempts} attempt(s) left.`,
+        });
+      } else {
+        toast.error("OTP invalid 3 times.", {
+          description: "Please resend OTP and try again.",
+        });
+      }
+
+      setOtp("");
+      setIsVerifying(false);
+    },
+    [email, failedAttempts],
+  );
+
+  const handleVerifyOtp = useCallback(() => {
+    if (otp.length !== OTP_LENGTH) {
+      toast.error("Please enter the full 6-digit OTP.");
+      return;
+    }
+
+    if (
+      isVerifying ||
+      isResending ||
+      hasReachedMaxAttempts ||
+      !email ||
+      isVerified
+    ) {
+      return;
+    }
+
+    void submitOtpVerification(otp);
+  }, [
+    email,
+    hasReachedMaxAttempts,
+    isResending,
+    isVerified,
+    isVerifying,
+    otp,
+    submitOtpVerification,
+  ]);
+
+  const handleResend = useCallback(async () => {
+    if (!email) return;
+    setIsResending(true);
+    const result = await resendOtp({ email });
+    if (result.ok) {
+      toast.success("New OTP sent!", {
+        description: "Please check your email inbox.",
+      });
+      sessionStorage.removeItem(RESET_VERIFIED_FLAG_KEY);
+      setOtp("");
+      setFailedAttempts(0);
+      setSecondsLeft(RESEND_SECONDS);
+    } else {
+      toast.error("Could not resend OTP.", { description: result.message });
+    }
+    setIsResending(false);
+  }, [email]);
+
+  return (
+    <div className="bg-surface font-body text-on-surface min-h-screen flex flex-col">
+      <Header isHomePage={false} />
+
+      <main className="flex-1 flex items-center justify-center px-6 pt-28 pb-10">
+        <div className="w-full max-w-md">
+          <Card className="w-full rounded-3xl border border-outline-variant bg-surface-container-lowest p-6 shadow-lg sm:p-8">
+            <CardContent className="space-y-6">
+              {/* Icon */}
+              <div className="flex justify-center">
+                <div className="flex size-16 items-center justify-center rounded-full bg-primary/10">
+                  <HugeiconsIcon
+                    icon={SquareLock02Icon}
+                    strokeWidth={1.5}
+                    className="size-8 text-primary"
+                  />
+                </div>
+              </div>
+
+              {/* Heading */}
+              <div className="space-y-2 text-center">
+                <h1 className="font-headline text-3xl font-bold tracking-tight text-on-surface">
+                  Verify OTP
+                </h1>
+                <p className="text-sm text-on-surface-variant">
+                  Enter the 6-digit code sent to your email to continue.
+                </p>
+                {email ? (
+                  <p className="text-xs text-on-surface-variant">
+                    Code sent to:{" "}
+                    <span className="font-medium text-on-surface">{email}</span>
+                  </p>
+                ) : (
+                  <p className="text-xs text-destructive">
+                    Missing email context.{" "}
+                    <Link
+                      to={PATHS.FORGOT_PASSWORD}
+                      className="underline text-primary"
+                    >
+                      Go back
+                    </Link>
+                  </p>
+                )}
+              </div>
+
+              {/* OTP Input */}
+              <div className="space-y-3">
+                <Label className="text-on-surface">OTP Code</Label>
+                <div className="rounded-2xl border border-outline-variant bg-surface-container p-4 sm:p-5">
+                  <InputOTP
+                    value={otp}
+                    onChange={(value) => setOtp(value.replaceAll(/\D/g, ""))}
+                    maxLength={OTP_LENGTH}
+                    containerClassName="justify-center"
+                    disabled={
+                      isVerifying ||
+                      isResending ||
+                      hasReachedMaxAttempts ||
+                      !email ||
+                      isVerified
+                    }
+                  >
+                    <InputOTPGroup className="gap-2 rounded-none">
+                      {Array.from(
+                        { length: OTP_LENGTH },
+                        (_, slotIndex) => slotIndex,
+                      ).map((slotIndex) => (
+                        <InputOTPSlot
+                          key={slotIndex}
+                          index={slotIndex}
+                          className="size-11 rounded-xl border border-outline-variant bg-surface-container-lowest text-base first:rounded-xl first:border"
+                        />
+                      ))}
+                    </InputOTPGroup>
+                  </InputOTP>
+                </div>
+
+                <Button
+                  type="button"
+                  onClick={handleVerifyOtp}
+                  disabled={
+                    otp.length !== OTP_LENGTH ||
+                    isVerifying ||
+                    isResending ||
+                    hasReachedMaxAttempts ||
+                    !email ||
+                    isVerified
+                  }
+                  className="w-full rounded-full py-6 text-base gap-2"
+                >
+                  {isVerifying ? (
+                    <>
+                      <HugeiconsIcon
+                        icon={Loading03Icon}
+                        strokeWidth={2}
+                        className="size-4 animate-spin"
+                      />
+                      Verifying OTP...
+                    </>
+                  ) : (
+                    <>
+                      Verify OTP
+                      <HugeiconsIcon
+                        icon={ArrowRight01Icon}
+                        strokeWidth={2}
+                        className="size-4"
+                      />
+                    </>
+                  )}
+                </Button>
+
+                {/* Resend row */}
+                <div className="flex items-center justify-between text-sm">
+                  <p className="text-on-surface-variant">
+                    {secondsLeft > 0
+                      ? `Resend in ${formatCountdown(secondsLeft)}`
+                      : "Didn't receive the code?"}
+                  </p>
+                  <Button
+                    type="button"
+                    variant="link"
+                    className="h-auto p-0 text-primary"
+                    disabled={secondsLeft > 0 || isResending || !email}
+                    onClick={handleResend}
+                  >
+                    {isResending ? (
+                      <span className="flex items-center gap-1">
+                        <HugeiconsIcon
+                          icon={Loading03Icon}
+                          strokeWidth={2}
+                          className="size-3 animate-spin"
+                        />
+                        Resending...
+                      </span>
+                    ) : (
+                      "Resend OTP"
+                    )}
+                  </Button>
+                </div>
+
+                <p className="text-center text-xs text-on-surface-variant">
+                  {isVerifying
+                    ? "Verifying OTP..."
+                    : `Remaining attempts: ${Math.max(MAX_FAILED_ATTEMPTS - failedAttempts, 0)}`}
+                </p>
+              </div>
+
+              <p className="text-center text-sm text-on-surface-variant">
+                <Link
+                  to={PATHS.FORGOT_PASSWORD}
+                  className="text-primary font-semibold hover:underline"
+                >
+                  ← Change email
+                </Link>
+                {" · "}
+                <Link
+                  to={PATHS.LOGIN}
+                  className="text-primary font-semibold hover:underline"
+                >
+                  Back to Sign In
+                </Link>
+              </p>
+            </CardContent>
+          </Card>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/pages/ResetPasswordPage.tsx
+++ b/frontend/src/pages/ResetPasswordPage.tsx
@@ -3,123 +3,127 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-  InputOTP,
-  InputOTPGroup,
-  InputOTPSlot,
-} from "@/components/ui/input-otp";
 import { PATHS } from "@/constants/paths";
-import { resetPassword, resendOtp } from "@/services/auth/authService";
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { ViewIcon, ViewOffSlashIcon, Key01Icon, Loading03Icon } from "@hugeicons/core-free-icons";
+import { resetPassword } from "@/services/auth/authService";
+import {
+  Key01Icon,
+  Loading03Icon,
+  ViewIcon,
+  ViewOffSlashIcon,
+} from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import type { ComponentProps, ReactNode } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { toast } from "sonner";
-import type { ComponentProps } from "react";
 
 type FormSubmitEvent = Parameters<
   NonNullable<ComponentProps<"form">["onSubmit"]>
 >[0];
 
-const OTP_LENGTH = 6;
-const RESEND_SECONDS = 60;
-
-function formatCountdown(seconds: number): string {
-  const minutes = Math.floor(seconds / 60);
-  const remainingSeconds = seconds % 60;
-  return `${String(minutes).padStart(2, "0")}:${String(remainingSeconds).padStart(2, "0")}`;
-}
+const RESET_VERIFIED_FLAG_KEY = "pendingResetVerified";
 
 export default function ResetPasswordPage() {
   const location = useLocation();
   const navigate = useNavigate();
+  const navigationState = useMemo(
+    () => location.state as { email?: string; verified?: boolean } | null,
+    [location.state],
+  );
 
+  // Email được truyền qua từ ResetPasswordOtpPage sau khi verify OTP thành công
   const email = useMemo(() => {
-    const stateValue = location.state as { email?: string } | null;
-    const fromState = stateValue?.email?.trim() ?? "";
+    const fromState = navigationState?.email?.trim() ?? "";
     if (fromState) return fromState;
     return (
       new URLSearchParams(location.search).get("email")?.trim() ??
       sessionStorage.getItem("pendingResetEmail")?.trim() ??
       ""
     );
-  }, [location.search, location.state]);
+  }, [location.search, navigationState]);
 
-  const [otp, setOtp] = useState("");
+  const isOtpVerified = useMemo(
+    () =>
+      Boolean(navigationState?.verified) ||
+      sessionStorage.getItem(RESET_VERIFIED_FLAG_KEY) === "1",
+    [navigationState],
+  );
+
   const [newPassword, setNewPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
   const [showNewPassword, setShowNewPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [isResending, setIsResending] = useState(false);
-  const [secondsLeft, setSecondsLeft] = useState(RESEND_SECONDS);
   const [isSuccess, setIsSuccess] = useState(false);
+  let submitContent: ReactNode = "Save New Password";
 
-  // Lưu email vào sessionStorage để giữ state khi reload
+  if (isSubmitting) {
+    submitContent = (
+      <>
+        <HugeiconsIcon
+          icon={Loading03Icon}
+          strokeWidth={2}
+          className="size-4 animate-spin"
+        />
+        Saving...
+      </>
+    );
+  } else if (isSuccess) {
+    submitContent = "Password Saved!";
+  }
+
   useEffect(() => {
-    if (email) sessionStorage.setItem("pendingResetEmail", email);
-  }, [email]);
+    if (!email || isOtpVerified) return;
 
-  // Countdown resend timer
-  useEffect(() => {
-    if (secondsLeft <= 0) return;
-    const id = window.setInterval(() => {
-      setSecondsLeft((prev) => {
-        if (prev <= 1) {
-          window.clearInterval(id);
-          return 0;
-        }
-        return prev - 1;
-      });
-    }, 1000);
-    return () => window.clearInterval(id);
-  }, [secondsLeft]);
+    toast.error("OTP verification required.", {
+      description: "Please verify OTP before setting a new password.",
+    });
 
-  // Redirect sau khi đổi mật khẩu thành công
+    navigate(`${PATHS.RESET_PASSWORD}?email=${encodeURIComponent(email)}`, {
+      replace: true,
+      state: { email },
+    });
+  }, [email, isOtpVerified, navigate]);
+
+  // Redirect về Login sau khi đặt mật khẩu thành công
   useEffect(() => {
     if (!isSuccess) return;
-    const id = window.setTimeout(() => {
-      sessionStorage.removeItem("pendingResetEmail");
-      navigate(
-        `${PATHS.LOGIN}${email ? `?email=${encodeURIComponent(email)}` : ""}`,
-      );
-    }, 1500);
-    return () => window.clearTimeout(id);
-  }, [email, isSuccess, navigate]);
+    const loginPath = email
+      ? `${PATHS.LOGIN}?email=${encodeURIComponent(email)}`
+      : PATHS.LOGIN;
 
-  const handleResend = useCallback(async () => {
-    if (!email) return;
-    setIsResending(true);
-    const result = await resendOtp({ email });
-    if (result.ok) {
-      toast.success("New OTP sent!", {
-        description: "Please check your email inbox.",
-      });
-      setOtp("");
-      setSecondsLeft(RESEND_SECONDS);
-    } else {
-      toast.error("Could not resend OTP.", { description: result.message });
-    }
-    setIsResending(false);
-  }, [email]);
+    const id = globalThis.setTimeout(() => {
+      sessionStorage.removeItem("pendingResetEmail");
+      sessionStorage.removeItem(RESET_VERIFIED_FLAG_KEY);
+      navigate(loginPath);
+    }, 1500);
+    return () => globalThis.clearTimeout(id);
+  }, [email, isSuccess, navigate]);
 
   const handleSubmit = async (event: FormSubmitEvent) => {
     event.preventDefault();
 
     if (!email) {
       toast.error("Email context missing.", {
-        description: "Please go back to Forgot Password.",
+        description: "Please start over from Forgot Password.",
       });
       return;
     }
 
-    if (otp.length !== OTP_LENGTH) {
-      toast.error("Please enter the complete 6-digit OTP.");
+    if (!isOtpVerified) {
+      toast.error("OTP not verified.", {
+        description: "Please complete OTP verification first.",
+      });
       return;
     }
 
     if (!newPassword) {
       toast.error("Please enter your new password.");
+      return;
+    }
+
+    if (newPassword.length < 6) {
+      toast.error("Password must be at least 6 characters.");
       return;
     }
 
@@ -130,7 +134,7 @@ export default function ResetPasswordPage() {
 
     setIsSubmitting(true);
 
-    const result = await resetPassword({ email, otp, newPassword });
+    const result = await resetPassword({ email, newPassword });
 
     if (result.ok) {
       setIsSuccess(true);
@@ -139,7 +143,6 @@ export default function ResetPasswordPage() {
       });
     } else {
       toast.error("Reset failed.", { description: result.message });
-      setOtp("");
     }
 
     setIsSubmitting(false);
@@ -156,21 +159,25 @@ export default function ResetPasswordPage() {
               {/* Icon */}
               <div className="flex justify-center">
                 <div className="flex size-16 items-center justify-center rounded-full bg-primary/10">
-                  <HugeiconsIcon icon={Key01Icon} strokeWidth={1.5} className="size-8 text-primary" />
+                  <HugeiconsIcon
+                    icon={Key01Icon}
+                    strokeWidth={1.5}
+                    className="size-8 text-primary"
+                  />
                 </div>
               </div>
 
               {/* Heading */}
               <div className="space-y-2 text-center">
                 <h1 className="font-headline text-3xl font-bold tracking-tight text-on-surface">
-                  Reset Password
+                  Set New Password
                 </h1>
                 <p className="text-sm text-on-surface-variant">
-                  Enter the OTP sent to your email and choose a new password.
+                  Choose a strong new password for your account.
                 </p>
                 {email ? (
                   <p className="text-xs text-on-surface-variant">
-                    Code sent to:{" "}
+                    Resetting password for:{" "}
                     <span className="font-medium text-on-surface">{email}</span>
                   </p>
                 ) : (
@@ -180,71 +187,26 @@ export default function ResetPasswordPage() {
                       to={PATHS.FORGOT_PASSWORD}
                       className="underline text-primary"
                     >
-                      Go back
+                      Start over
                     </Link>
                   </p>
                 )}
               </div>
 
               <form className="space-y-5" onSubmit={handleSubmit}>
-                {/* OTP Input */}
-                <div className="space-y-3">
-                  <Label className="text-on-surface">OTP Code</Label>
-                  <div className="rounded-2xl border border-outline-variant bg-surface-container p-4">
-                    <InputOTP
-                      value={otp}
-                      onChange={(value) => setOtp(value.replace(/\D/g, ""))}
-                      maxLength={OTP_LENGTH}
-                      containerClassName="justify-center"
-                      disabled={isSubmitting || isResending || !email}
-                    >
-                      <InputOTPGroup className="gap-2 rounded-none">
-                        {Array.from({ length: OTP_LENGTH }).map((_, i) => (
-                          <InputOTPSlot
-                            key={i}
-                            index={i}
-                            className="size-11 rounded-xl border border-outline-variant bg-surface-container-lowest text-base first:rounded-xl first:border"
-                          />
-                        ))}
-                      </InputOTPGroup>
-                    </InputOTP>
-                  </div>
-
-                  {/* Resend row */}
-                  <div className="flex items-center justify-between text-sm">
-                    <p className="text-on-surface-variant">
-                      {secondsLeft > 0
-                        ? `Resend in ${formatCountdown(secondsLeft)}`
-                        : "Didn't receive the code?"}
-                    </p>
-                    <Button
-                      type="button"
-                      variant="link"
-                      className="h-auto p-0 text-primary"
-                      disabled={secondsLeft > 0 || isResending || !email}
-                      onClick={handleResend}
-                    >
-                      {isResending ? "Resending..." : "Resend OTP"}
-                    </Button>
-                  </div>
-                </div>
-
                 {/* New Password */}
                 <div className="space-y-2">
-                  <Label
-                    htmlFor="reset-new-password"
-                    className="text-on-surface"
-                  >
+                  <Label htmlFor="new-password" className="text-on-surface">
                     New Password
                   </Label>
                   <div className="relative">
                     <Input
-                      id="reset-new-password"
+                      id="new-password"
                       type={showNewPassword ? "text" : "password"}
                       autoComplete="new-password"
                       value={newPassword}
                       onChange={(e) => setNewPassword(e.target.value)}
-                      disabled={isSubmitting}
+                      disabled={isSubmitting || isSuccess}
                       placeholder="At least 6 characters"
                       className="border-outline-variant bg-surface-container-lowest placeholder:text-on-surface-variant focus-visible:border-primary focus-visible:ring-primary-fixed/60 pr-10"
                     />
@@ -252,9 +214,7 @@ export default function ResetPasswordPage() {
                       type="button"
                       tabIndex={-1}
                       aria-label={
-                        showNewPassword
-                          ? "Hide new password"
-                          : "Show new password"
+                        showNewPassword ? "Hide password" : "Show password"
                       }
                       onClick={() => setShowNewPassword((p) => !p)}
                       className="absolute inset-y-0 right-3 flex items-center text-on-surface-variant hover:text-on-surface transition-colors"
@@ -270,20 +230,17 @@ export default function ResetPasswordPage() {
 
                 {/* Confirm Password */}
                 <div className="space-y-2">
-                  <Label
-                    htmlFor="reset-confirm-password"
-                    className="text-on-surface"
-                  >
+                  <Label htmlFor="confirm-password" className="text-on-surface">
                     Confirm Password
                   </Label>
                   <div className="relative">
                     <Input
-                      id="reset-confirm-password"
+                      id="confirm-password"
                       type={showConfirmPassword ? "text" : "password"}
                       autoComplete="new-password"
                       value={confirmPassword}
                       onChange={(e) => setConfirmPassword(e.target.value)}
-                      disabled={isSubmitting}
+                      disabled={isSubmitting || isSuccess}
                       placeholder="Repeat your new password"
                       className="border-outline-variant bg-surface-container-lowest placeholder:text-on-surface-variant focus-visible:border-primary focus-visible:ring-primary-fixed/60 pr-10"
                     />
@@ -310,19 +267,12 @@ export default function ResetPasswordPage() {
                 <Button
                   type="submit"
                   id="reset-password-submit"
-                  disabled={isSubmitting || isSuccess || !email}
+                  disabled={
+                    isSubmitting || isSuccess || !email || !isOtpVerified
+                  }
                   className="w-full rounded-full py-6 text-base gap-2"
                 >
-                  {isSubmitting ? (
-                    <>
-                      <HugeiconsIcon icon={Loading03Icon} strokeWidth={2} className="size-4 animate-spin" />
-                      Resetting...
-                    </>
-                  ) : isSuccess ? (
-                    "Password Reset!"
-                  ) : (
-                    "Reset Password"
-                  )}
+                  {submitContent}
                 </Button>
               </form>
 
@@ -331,7 +281,7 @@ export default function ResetPasswordPage() {
                   to={PATHS.FORGOT_PASSWORD}
                   className="text-primary font-semibold hover:underline"
                 >
-                  ← Change email address
+                  ← Start over
                 </Link>
                 {" · "}
                 <Link

--- a/frontend/src/routes/routesConfig.ts
+++ b/frontend/src/routes/routesConfig.ts
@@ -3,6 +3,7 @@ import ForgotPasswordPage from "@/pages/ForgotPasswordPage";
 import LoginPage from "@/pages/LoginPage";
 import OnboardingPage from "@/pages/OnboardingPage";
 import RegisterPage from "@/pages/RegisterPage";
+import ResetPasswordOtpPage from "@/pages/ResetPasswordOtpPage";
 import ResetPasswordPage from "@/pages/ResetPasswordPage";
 import VerifyOtpPage from "@/pages/VerifyOtpPage";
 
@@ -40,6 +41,11 @@ export const routesConfig: RouteConfig[] = [
   },
   {
     path: PATHS.RESET_PASSWORD,
+    element: ResetPasswordOtpPage,
+    isPrivate: false,
+  },
+  {
+    path: PATHS.RESET_PASSWORD_NEW,
     element: ResetPasswordPage,
     isPrivate: false,
   },

--- a/frontend/src/services/auth/authService.ts
+++ b/frontend/src/services/auth/authService.ts
@@ -26,6 +26,7 @@ const DEFAULT_ME_ENDPOINT = "/auth/me";
 const DEFAULT_FORGOT_PASSWORD_ENDPOINT = "/auth/forgot-password";
 const DEFAULT_RESEND_OTP_ENDPOINT = "/auth/resend-otp";
 const DEFAULT_RESET_PASSWORD_ENDPOINT = "/auth/reset-password";
+const DEFAULT_VERIFY_OTP_ENDPOINT = "/auth/verify-otp";
 
 function buildAuthUrl(endpointValue: string, defaultEndpoint: string): string {
   const baseUrl = (
@@ -108,6 +109,13 @@ function getResetPasswordUrl(): string {
   );
 }
 
+function getVerifyOtpUrl(): string {
+  return buildAuthUrl(
+    import.meta.env.VITE_VERIFY_OTP_ENDPOINT ?? "",
+    DEFAULT_VERIFY_OTP_ENDPOINT,
+  );
+}
+
 function readMessage(data: unknown): string | null {
   if (!data || typeof data !== "object") {
     return null;
@@ -137,14 +145,11 @@ function readMessage(data: unknown): string | null {
 /** JSON headers dùng chung cho các request có body */
 const JSON_HEADERS = {
   "Content-Type": "application/json",
-  "Accept": "application/json",
+  Accept: "application/json",
   "Accept-Encoding": "gzip, deflate, br",
-  "Connection": "keep-alive",
+  Connection: "keep-alive",
 };
 
-// ---------------------------------------------------------------------------
-// POST /auth/register
-// ---------------------------------------------------------------------------
 export async function registerUser(
   payload: RegisterRequest,
 ): Promise<RegisterResponse> {
@@ -192,9 +197,6 @@ export async function registerUser(
   }
 }
 
-// ---------------------------------------------------------------------------
-// POST /auth/verify-email
-// ---------------------------------------------------------------------------
 export async function verifyEmailOtp(
   payload: VerifyEmailOtpRequest,
 ): Promise<VerifyEmailOtpResponse> {
@@ -236,11 +238,6 @@ export async function verifyEmailOtp(
   }
 }
 
-// ---------------------------------------------------------------------------
-// POST /auth/login
-// Backend trả về: ApiResponse<{ accessToken, tokenType, expiresIn }>
-// Refresh Token được set tự động vào HttpOnly cookie "sp_refresh_token"
-// ---------------------------------------------------------------------------
 export async function loginUser(payload: LoginRequest): Promise<LoginResponse> {
   const loginUrl = getLoginUrl();
 
@@ -286,11 +283,6 @@ export async function loginUser(payload: LoginRequest): Promise<LoginResponse> {
   }
 }
 
-// ---------------------------------------------------------------------------
-// POST /auth/refresh
-// Gửi HttpOnly cookie "sp_refresh_token" (tự động do trình duyệt)
-// Backend trả về: ApiResponse<{ accessToken, tokenType, expiresIn }>
-// ---------------------------------------------------------------------------
 export async function refreshToken(): Promise<RefreshResponse> {
   const refreshUrl = getRefreshUrl();
 
@@ -338,10 +330,6 @@ export async function refreshToken(): Promise<RefreshResponse> {
   }
 }
 
-// ---------------------------------------------------------------------------
-// POST /auth/logout
-// Backend xóa cookie "sp_refresh_token" bằng cách set maxAge=0
-// ---------------------------------------------------------------------------
 export async function logoutUser(): Promise<LogoutResponse> {
   const logoutUrl = getLogoutUrl();
 
@@ -384,9 +372,6 @@ export async function logoutUser(): Promise<LogoutResponse> {
   }
 }
 
-// ---------------------------------------------------------------------------
-// GET /auth/me  (cần Access Token trong Authorization header)
-// ---------------------------------------------------------------------------
 export async function getCurrentUser(accessToken: string): Promise<MeResponse> {
   const meUrl = getMeUrl();
 
@@ -416,9 +401,7 @@ export async function getCurrentUser(accessToken: string): Promise<MeResponse> {
         ok: false,
         status,
         message:
-          readMessage(data) ??
-          error.message ??
-          "Failed to fetch current user.",
+          readMessage(data) ?? error.message ?? "Failed to fetch current user.",
         data: undefined,
       };
     }
@@ -430,9 +413,6 @@ export async function getCurrentUser(accessToken: string): Promise<MeResponse> {
   }
 }
 
-// ---------------------------------------------------------------------------
-// POST /auth/forgot-password
-// ---------------------------------------------------------------------------
 export async function forgotPassword(
   payload: ForgotPasswordRequest,
 ): Promise<PasswordResponse> {
@@ -467,14 +447,12 @@ export async function forgotPassword(
 
     return {
       ok: false,
-      message: "Unexpected error occurred while sending forgot password request.",
+      message:
+        "Unexpected error occurred while sending forgot password request.",
     };
   }
 }
 
-// ---------------------------------------------------------------------------
-// POST /auth/resend-otp
-// ---------------------------------------------------------------------------
 export async function resendOtp(
   payload: ResendOtpRequest,
 ): Promise<PasswordResponse> {
@@ -514,9 +492,6 @@ export async function resendOtp(
   }
 }
 
-// ---------------------------------------------------------------------------
-// POST /auth/reset-password
-// ---------------------------------------------------------------------------
 export async function resetPassword(
   payload: ResetPasswordRequest,
 ): Promise<PasswordResponse> {
@@ -556,6 +531,46 @@ export async function resetPassword(
   }
 }
 
+export async function verifyResetOtp(payload: {
+  email: string;
+  otp: string;
+}): Promise<PasswordResponse> {
+  const url = getVerifyOtpUrl();
+
+  try {
+    const response = await axios.post(url, payload, {
+      headers: JSON_HEADERS,
+    });
+
+    return {
+      ok: true,
+      status: response.status,
+      message:
+        readMessage(response.data) ??
+        `OTP verified successfully with status ${response.status}.`,
+    };
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      const status = error.response?.status;
+      const data = error.response?.data;
+
+      return {
+        ok: false,
+        status,
+        message:
+          readMessage(data) ??
+          error.message ??
+          "OTP verification failed. Please try again.",
+      };
+    }
+
+    return {
+      ok: false,
+      message: "Unexpected error occurred while verifying OTP.",
+    };
+  }
+}
+
 export async function getMeAuth(): Promise<LoginResponse> {
   const sessionUrl = getMeUrl();
 
@@ -564,9 +579,9 @@ export async function getMeAuth(): Promise<LoginResponse> {
       headers: {
         "Content-Type": "application/json",
         "Content-Length": JSON.stringify({}).length,
-        "Accept": "application/json",
+        Accept: "application/json",
         "Accept-Encoding": "gzip, deflate, br",
-        "Connection": "keep-alive", // persistent connection
+        Connection: "keep-alive", // persistent connection
       },
       withCredentials: true,
     });
@@ -587,10 +602,7 @@ export async function getMeAuth(): Promise<LoginResponse> {
       return {
         ok: false,
         status,
-        message:
-          readMessage(data) ??
-          error.message ??
-          "Session check failed.",
+        message: readMessage(data) ?? error.message ?? "Session check failed.",
         data,
       };
     }

--- a/frontend/src/types/request/ResetPasswordRequest.ts
+++ b/frontend/src/types/request/ResetPasswordRequest.ts
@@ -1,5 +1,4 @@
 export type ResetPasswordRequest = {
   email: string;
-  otp: string;
   newPassword: string;
 };


### PR DESCRIPTION

- Added ResetPasswordOtpPage for OTP verification before resetting password.
- Updated ResetPasswordPage to remove OTP input and handle password reset directly after OTP verification.
- Modified ResetPasswordRequest type to remove OTP field.
- Enhanced ForgotPasswordPage to store email for OTP verification.
- Updated authService to include verifyResetOtp function for OTP verification.
- Adjusted routing to include new ResetPasswordOtpPage.
- Improved UI components for better user experience during password reset process.